### PR TITLE
Really delete the backup database

### DIFF
--- a/src/git-sqlite-merge.in
+++ b/src/git-sqlite-merge.in
@@ -80,8 +80,8 @@ fi
 
 # git seems to clean up the backup regardless,
 # but if its still here lets get rid of it
-if [ -e "$backup" ]; then
-    rm "$backup"
+if [ -e "$backupDb" ]; then
+    rm "$backupDb"
 fi
 
 # apply the diff


### PR DESCRIPTION
The variable name was apparently typo'd.

(You might want to consider setting "set -u" to make sure no undefined variables are read from. Likewise, "set -e" might be useful, to stop execution on a failed command.)